### PR TITLE
Fix save menu for photo editor

### DIFF
--- a/src/components/pages/PhotoEditor.tsx
+++ b/src/components/pages/PhotoEditor.tsx
@@ -13,6 +13,7 @@ const PhotoEditor: React.FC<PhotoEditorProps> = ({ image, onSave, onClose }) => 
             source={image}
             savingPixelRatio={1}
             previewPixelRatio={1}
+            onBeforeSave={() => false}
             onSave={(ImageData) => {
                 if (ImageData.imageBase64) {
                     onSave(ImageData.imageBase64);


### PR DESCRIPTION
### Описание изменений
Фикс, убирает меню сохранения в едиторе фото

### Зачем нужны эти изменения?
Нажатие save в едиторе сразу сохраняет фото

### Чек-лист
- [x] Я проверил(-а) изменения в локальной среде
- [x] Я добавил(а) тесты, чтобы покрыть свои изменения
- [x] Все существующие и новые тесты проходят успешно